### PR TITLE
aruco_make.py : add grey option and tight border

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ optional arguments:
                         first marker to generate, default= 0
   -e END, --end END     last marker to generate default= -1
   -v, --view            show marker on monitor
+  -g, --grey            generate black/grey marker
 ```
 
 ### gcp\_check.py

--- a/aruco_make.py
+++ b/aruco_make.py
@@ -11,6 +11,7 @@ import matplotlib as mpl
 def_dict = aruco.DICT_4X4_100   # default dictionary 4X4
 def_start = 0                   # first marker to generate
 def_end = -1                    # last marker to generate
+def_grey = 95                   # grey color
 
 # set up command line argument parser
 parser = argparse.ArgumentParser()
@@ -22,6 +23,8 @@ parser.add_argument('-e', '--end', type=int, default=def_end,
     help='last marker to generate default= {}'.format(def_end))
 parser.add_argument('-v', '--view', action="store_true",
     help='show marker on monitor')
+parser.add_argument('-g', '--grey', action="store_true",
+    help='generate black/grey marker to reduce burnt in effect')
 args = parser.parse_args()
 
 if args.dict == 99:     # use special 3x3 dictionary
@@ -33,8 +36,11 @@ if args.end < args.start:
 #fig = plt.figure()
 for i in range(args.start, args.end+1):
     img = aruco.drawMarker(aruco_dict, i, 1000)
+    if args.grey:
+        img[img[:,:] == 255] = def_grey
+        plt.figure(facecolor=str(def_grey/255))
     plt.axis('off')
-    plt.imshow(img, cmap=mpl.cm.gray, interpolation="nearest")
-    plt.savefig("marker{}.png".format(i))
+    plt.imshow(img, cmap=mpl.cm.gray, vmin=0, vmax=255, interpolation="nearest")
+    plt.savefig("marker{}.png".format(i), bbox_inches='tight', pad_inches=0.5)
     if args.view:
         plt.show()


### PR DESCRIPTION
I added an option to aruco_make.py to generate black/grey marker to reduce burnt in effect