### PR TITLE
Robust native version checker

### DIFF
--- a/aruco_make.py
+++ b/aruco_make.py
@@ -4,12 +4,13 @@
     Simple application to generate ArUco markers of different dictionaries
 """
 import argparse
+import packaging.version
 import cv2
 from cv2 import aruco
 import matplotlib.pyplot as plt
 
 # handle incompatibility introduced in openCV 4.8
-if cv2.__version__ < '4.7':
+if packaging.version.parse(cv2.__version__) < packaging.version.parse('4.7'):
     aruco.extendDictionary = aruco.Dictionary_create
     aruco.getPredefinedDictionary = aruco.Dictionary_get
     aruco.generateImageMarker = aruco.drawMarker

--- a/gcp_find.py
+++ b/gcp_find.py
@@ -17,6 +17,7 @@ import time
 import glob
 import json
 import argparse
+import packaging.version
 import numpy as np
 from numpy.linalg import norm
 import matplotlib.pyplot as plt
@@ -24,7 +25,7 @@ import cv2
 from cv2 import aruco
 
 # handle incompatibility introduced in openCV 4.8
-if cv2.__version__ < '4.7':
+if packaging.version.parse(cv2.__version__) < packaging.version.parse('4.7'):
     aruco.extendDictionary = aruco.Dictionary_create
     aruco.getPredefinedDictionary = aruco.Dictionary_get
     aruco.DetectorParameters = aruco.DetectorParameters_create
@@ -182,7 +183,7 @@ class GcpFind():
         else:
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
         # find markers
-        if cv2.__version__ < '4.8':
+        if packaging.version.parse(cv2.__version__) < packaging.version.parse('4.8'):
             corners, ids, _ = aruco.detectMarkers(gray,
                                                   self.aruco_dict,
                                                   parameters=self.params)


### PR DESCRIPTION
When `cv2` migrated to version 4.10.0 the comparison used is causing errors.

This solution uses a native lib in python to better handle version comparisons.